### PR TITLE
Update LAB_AK_01_Lab1_Ex1_Explore_M365_Defender.md

### DIFF
--- a/Instructions/Labs/LAB_AK_01_Lab1_Ex1_Explore_M365_Defender.md
+++ b/Instructions/Labs/LAB_AK_01_Lab1_Ex1_Explore_M365_Defender.md
@@ -88,25 +88,4 @@ In this task, you will assign preset security policies for Exchange Online Prote
 1. Read the content under *Review and confirm your changes* and select **Confirm** to apply the changes and then select **Done** to finish.
 
     >**Note:** If you receive the message *"The URI 'https://outlook.office365.com/psws/service.svc/AntiPhishPolicy' is not valid for PUT operation. The URI must point to a single resource for PUT operations."* just select **OK** and then select **Cancel** to return to the main page. You will see the *Strict protection is on* option enabled.
-
-### Task 3: Preparing the Microsoft 365 Defender workspace
-
-1. On the **Microsoft 365 Defender** portal, from the navigation menu, select **Home** from the left.
-
-    >**Note:** You may need to scroll all the way to the menu top.
-
-1. On the **Home** portal page, **Welcome to Microsoft 365 Defender** is displayed.
-
-1. Scroll down through the tiles until you find the tile labeled **Microsoft 365 Defender** with the message, **Turn on Microsoft 365 Defender.**
-
-    >**Hint:** It should be at the bottom right of the tiles.
-
-1. Select the button that says **Turn new features on.**
-
-1. You will see messages saying *loading and Initializing* briefly displayed at the top of the page, and then you're going to see an image of a coffee mug and a message that reads: **Hang on! We're preparing new spaces for your data and connecting them.** It will take approximately 5 minutes to finish. *Leave the page open and make sure it finishes since it is required for the next Lab.*
-
-    >**Note:** If the message "Hang on! We're preparing new spaces for your data and connecting them" does not appear, or the "Settings > Microsoft 365 Defender > Account" page opens, but you see the message "Failed to load data storage location. Please try again later",  select "Alert service settings" from the "General" menu, or go to the navigation menu, scroll down to the "Assets" section and select "Devices".
-
-1. When the new space completes successfully, you are going to see the Microsoft 365 Defender General settings for Account, Email notifications, Alert service settings, Permissions and roles and Streaming API. You will also see **Preview Features** turned on.
-
 ## You have completed the lab


### PR DESCRIPTION
Task 3 can be removed, there is no longer a tile option to turn on 365 Defender as it is already on and enabled on the tenants provided by the authorised lab hosts

**Replace issue name M00-LAB00:QUICK_DESCRIPTION, for example "M01-LAB01: My new issue" (or same name as linked Issue)**

## Related Issue

**Link related Github Issue** 🢂 Fixes # . (Include issue number after #)

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [ ] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [ ] Tested it
- [ ] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

-
-
-
